### PR TITLE
Fix lots and lots of warnings

### DIFF
--- a/IO.Ably.DeltaCodec/DataHelpers.cs
+++ b/IO.Ably.DeltaCodec/DataHelpers.cs
@@ -21,15 +21,14 @@ namespace IO.Ably.DeltaCodec
             {
                 return data as byte[];
             }
-            else if (data is string)
+
+            if (data is string)
             {
-                string dataAsString = data as string;
+                var dataAsString = data as string;
                 return TryConvertFromBase64String(dataAsString, out byte[] result) ? result : Encoding.UTF8.GetBytes(dataAsString);
             }
-            else
-            {
-                throw new ArgumentException("data parameter can only be of type `byte[]` or `string`");
-            }
+
+            throw new ArgumentException("data parameter can only be of type `byte[]` or `string`");
         }
 
         /// <summary>
@@ -41,8 +40,8 @@ namespace IO.Ably.DeltaCodec
         /// <returns>`true` or `false` depending on whether the conversion succeeded.</returns>
         public static bool TryConvertToDeltaByteArray(object obj, out byte[] delta)
         {
-            byte[] dataAsByteArray = obj as byte[];
-            string dataAsString = obj as string;
+            var dataAsByteArray = obj as byte[];
+            var dataAsString = obj as string;
             if (dataAsByteArray != null || (dataAsString != null && TryConvertFromBase64String(dataAsString, out dataAsByteArray)))
             {
                 delta = dataAsByteArray;

--- a/IO.Ably.DeltaCodec/DeltaApplicationResult.cs
+++ b/IO.Ably.DeltaCodec/DeltaApplicationResult.cs
@@ -7,30 +7,30 @@ namespace IO.Ably.DeltaCodec
     /// </summary>
     public class DeltaApplicationResult
     {
-        private readonly byte[] data;
+        private readonly byte[] _data;
 
         internal DeltaApplicationResult(byte[] data)
         {
-            this.data = data;
+            _data = data;
         }
-        
+
         /// <summary>
         /// Exports the delta application result as byte[]
         /// </summary>
         /// <returns>byte[] representation of this delta application result</returns>
         public byte[] AsByteArray()
         {
-            return this.data;
+            return _data;
         }
 
         /// <summary>
-        /// Exports the delta application result as string assuming the bytes in the result represent 
+        /// Exports the delta application result as string assuming the bytes in the result represent
         /// an UTF-8 encoded string.
         /// </summary>
         /// <returns>The UTF-8 string representation of this delta application result</returns>
         public string AsUtf8String()
         {
-            return Encoding.UTF8.GetString(this.data);
+            return Encoding.UTF8.GetString(_data);
         }
     }
 }

--- a/IO.Ably.DeltaCodec/DeltaDecoder.cs
+++ b/IO.Ably.DeltaCodec/DeltaDecoder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using IO.Ably.DeltaCodec.Vcdiff;
 
 namespace IO.Ably.DeltaCodec
 {
@@ -27,7 +28,7 @@ namespace IO.Ably.DeltaCodec
         /// </summary>
         /// <param name="delta">The delta to be applied</param>
         /// <param name="deltaId">(Optional) Sequence ID of the current delta application result. If set, it will be used for sequence continuity check during the next delta application</param>
-        /// <param name="baseId">(Optional) Sequence ID of the expected previous delta application result. If set, it will be used to perform sequence continuity check agains the last preserved sequence ID</param>
+        /// <param name="baseId">(Optional) Sequence ID of the expected previous delta application result. If set, it will be used to perform sequence continuity check against the last preserved sequence ID</param>
         /// <returns><see cref="DeltaApplicationResult"/> instance</returns>
         /// <exception cref="InvalidOperationException">The decoder is not initialized by calling <see cref="SetBase(byte[], string)"/></exception>
         /// <exception cref="SequenceContinuityException">The provided <paramref name="baseId"/> does not match the last preserved sequence ID</exception>
@@ -62,11 +63,11 @@ namespace IO.Ably.DeltaCodec
         /// <returns><see cref="DeltaApplicationResult"/> instance</returns>
         public static DeltaApplicationResult ApplyDelta(byte[] @base, byte[] delta)
         {
-            using (MemoryStream baseStream = new MemoryStream(@base))
-            using (MemoryStream deltaStream = new MemoryStream(delta))
-            using (MemoryStream decodedStream = new MemoryStream())
+            using (var baseStream = new MemoryStream(@base))
+            using (var deltaStream = new MemoryStream(delta))
+            using (var decodedStream = new MemoryStream())
             {
-                Vcdiff.VcdiffDecoder.Decode(baseStream, deltaStream, decodedStream);
+                VcdiffDecoder.Decode(baseStream, deltaStream, decodedStream);
 
                 return new DeltaApplicationResult(decodedStream.ToArray());
             }

--- a/IO.Ably.DeltaCodec/Vcdiff/AddressCache.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/AddressCache.cs
@@ -3,75 +3,75 @@ using System.IO;
 
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Cache used for encoding/decoding addresses.
-	/// </summary>
-	internal sealed class AddressCache
-	{
-		const byte SelfMode = 0;
-		const byte HereMode = 1;
+    /// <summary>
+    /// Cache used for encoding/decoding addresses.
+    /// </summary>
+    internal sealed class AddressCache
+    {
+        private const byte SelfMode = 0;
+        private const byte HereMode = 1;
 
-		int nearSize;
-		int sameSize;
-		int[] near;
-		int nextNearSlot;
-		int[] same;
+        private readonly int _nearSize;
+        private readonly int _sameSize;
+        private readonly int[] _near;
+        private int _nextNearSlot;
+        private readonly int[] _same;
 
-		Stream addressStream;
+        private Stream _addressStream;
 
-		internal AddressCache(int nearSize, int sameSize)
-		{
-			this.nearSize = nearSize;
-			this.sameSize = sameSize;
-			near = new int[nearSize];
-			same = new int[sameSize*256];
-		}
+        internal AddressCache(int nearSize, int sameSize)
+        {
+            _nearSize = nearSize;
+            _sameSize = sameSize;
+            _near = new int[nearSize];
+            _same = new int[sameSize*256];
+        }
 
-		internal void Reset(byte[] addresses)
-		{
-			nextNearSlot = 0;
-			Array.Clear(near, 0, near.Length);
-			Array.Clear(same, 0, same.Length);
+        internal void Reset(byte[] addresses)
+        {
+            _nextNearSlot = 0;
+            Array.Clear(_near, 0, _near.Length);
+            Array.Clear(_same, 0, _same.Length);
 
-			addressStream = new MemoryStream(addresses, false);
-		}
+            _addressStream = new MemoryStream(addresses, false);
+        }
 
-		internal int DecodeAddress (int here, byte mode)
-		{
-			int ret;
-			if (mode==SelfMode)
-			{
-				ret = IOHelper.ReadBigEndian7BitEncodedInt(addressStream);
-			}
-			else if (mode==HereMode)
-			{
-				ret = here - IOHelper.ReadBigEndian7BitEncodedInt(addressStream);
-			}
-			else if (mode-2 < nearSize) // Near cache
-			{
-				ret = near[mode-2] + IOHelper.ReadBigEndian7BitEncodedInt(addressStream);
-			}
-			else // Same cache
-			{
-				int m = mode-(2+nearSize);
-				ret = same[(m*256)+IOHelper.CheckedReadByte(addressStream)];
-			}
+        internal int DecodeAddress(int here, byte mode)
+        {
+            int ret;
+            if (mode == SelfMode)
+            {
+                ret = IoHelper.ReadBigEndian7BitEncodedInt(_addressStream);
+            }
+            else if (mode == HereMode)
+            {
+                ret = here - IoHelper.ReadBigEndian7BitEncodedInt(_addressStream);
+            }
+            else if (mode - 2 < _nearSize) // Near cache
+            {
+                ret = _near[mode - 2] + IoHelper.ReadBigEndian7BitEncodedInt(_addressStream);
+            }
+            else // Same cache
+            {
+                int m = mode - (2 + _nearSize);
+                ret = _same[(m * 256) + IoHelper.CheckedReadByte(_addressStream)];
+            }
 
-			Update (ret);
-			return ret;
-		}
+            Update (ret);
+            return ret;
+        }
 
-		void Update (int address)
-		{
-			if (nearSize > 0)
-			{
-				near[nextNearSlot] = address;
-				nextNearSlot=(nextNearSlot+1)%nearSize;
-			}
-			if (sameSize > 0)
-			{
-				same[address%(sameSize*256)] = address;
-			}
-		}
-	}
+        private void Update (int address)
+        {
+            if (_nearSize > 0)
+            {
+                _near[_nextNearSlot] = address;
+                _nextNearSlot = (_nextNearSlot + 1) % _nearSize;
+            }
+            if (_sameSize > 0)
+            {
+                _same[address % (_sameSize * 256)] = address;
+            }
+        }
+    }
 }

--- a/IO.Ably.DeltaCodec/Vcdiff/Adler32.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/Adler32.cs
@@ -1,115 +1,115 @@
+using System;
 using System.IO;
 
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Implementation of the Adler32 checksum routine.
-	/// TODO: Derive from HashAlgorithm.
-	/// </summary>
-	internal class Adler32
-	{
+    /// <summary>
+    /// Implementation of the Adler32 checksum routine.
+    /// TODO: Derive from HashAlgorithm.
+    /// </summary>
+    internal static class Adler32
+    {
         /// <summary>
         /// Base for modulo arithmetic
         /// </summary>
-		const int Base = 65521;
+        private const int Base = 65521;
 
         /// <summary>
         /// Number of iterations we can safely do before applying the modulo.
         /// </summary>
-		const int NMax = 5552;
+        private const int NMax = 5552;
 
-		/// <summary>
-		/// Computes the Adler32 checksum for the given data.
-		/// </summary>
-		/// <param name="initial">
-		/// Initial value or previous result. Use 1 for the
-		/// first transformation.
-		/// </param>
-		/// <param name="data">The data to compute the checksum of</param>
-		/// <param name="start">Index of first byte to compute checksum for</param>
-		/// <param name="length">Number of bytes to compute checksum for</param>
-		/// <returns>The checksum of the given data</returns>
-		public static int ComputeChecksum (int initial, byte[] data, int start, int length)
-		{
-			if (data == null)
-			{
-				throw (new System.ArgumentNullException("data"));
-			}
-			uint s1 = (uint)(initial & 0xffff);
-			uint s2 = (uint)((initial >> 16) & 0xffff);
+        /// <summary>
+        /// Computes the Adler32 checksum for the given data.
+        /// </summary>
+        /// <param name="initial">
+        /// Initial value or previous result. Use 1 for the
+        /// first transformation.
+        /// </param>
+        /// <param name="data">The data to compute the checksum of</param>
+        /// <param name="start">Index of first byte to compute checksum for</param>
+        /// <param name="length">Number of bytes to compute checksum for</param>
+        /// <returns>The checksum of the given data</returns>
+        public static int ComputeChecksum (int initial, byte[] data, int start, int length)
+        {
+            if (data == null)
+            {
+                throw (new ArgumentNullException(nameof(data)));
+            }
+            uint s1 = (uint)(initial & 0xffff);
+            uint s2 = (uint)((initial >> 16) & 0xffff);
 
-			int index=start;
-			int len = length;
+            int index = start;
+            int len = length;
 
-			int k;
-			while (len > 0)
-			{
-				k = (len < NMax) ? len : NMax;
-				len -= k;
+                        while (len > 0)
+            {
+                var k = (len < NMax) ? len : NMax;
+                len -= k;
 
-				for (int i=0; i < k; i++)
-				{
-					s1 += data[index++];
-					s2 += s1;
-				}
-				s1 %= Base;
-				s2 %= Base;
-			}
+                for (int i = 0; i < k; i++)
+                {
+                    s1 += data[index++];
+                    s2 += s1;
+                }
+                s1 %= Base;
+                s2 %= Base;
+            }
 
-			return (int)((s2<<16) | s1);
-		}
+            return (int)((s2<<16) | s1);
+        }
 
-		/// <summary>
-		/// Computes the Adler32 checksum for the given data.
-		/// </summary>
-		/// <param name="initial">
-		/// Initial value or previous result. Use 1 for the
-		/// first transformation.
-		/// </param>
-		/// <param name="data">The data to compute the checksum of</param>
-		/// <returns>The checksum of the given data</returns>
-		public static int ComputeChecksum (int initial, byte[] data)
-		{
-			if (data == null)
-			{
-				throw (new System.ArgumentNullException("data"));
-			}
-			return ComputeChecksum(initial, data, 0, data.Length);
-		}
+        /// <summary>
+        /// Computes the Adler32 checksum for the given data.
+        /// </summary>
+        /// <param name="initial">
+        /// Initial value or previous result. Use 1 for the
+        /// first transformation.
+        /// </param>
+        /// <param name="data">The data to compute the checksum of</param>
+        /// <returns>The checksum of the given data</returns>
+        public static int ComputeChecksum (int initial, byte[] data)
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+            return ComputeChecksum(initial, data, 0, data.Length);
+        }
 
-		/// <summary>
-		/// Computes the checksum for a stream, starting from the current
-		/// position and reading until no more can be read
-		/// </summary>
-		/// <param name="stream">The stream to compute the checksum for</param>
-		/// <returns>The checksum for the stream</returns>
-		public static int ComputeChecksum (Stream stream)
-		{
-			if (stream == null)
-			{
-				throw (new System.ArgumentNullException("stream"));
-			}
-			byte[] buffer = new byte[8172];
-			int size;
-			int checksum=1;
-			while ((size = stream.Read(buffer, 0, buffer.Length)) > 0)
-			{
-				checksum = ComputeChecksum(checksum, buffer, 0, size);
-			}
-			return checksum;
-		}
+        /// <summary>
+        /// Computes the checksum for a stream, starting from the current
+        /// position and reading until no more can be read
+        /// </summary>
+        /// <param name="stream">The stream to compute the checksum for</param>
+        /// <returns>The checksum for the stream</returns>
+        public static int ComputeChecksum (Stream stream)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            var buffer = new byte[8172];
+            int size;
+            int checksum = 1 ;
+            while ((size = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                checksum = ComputeChecksum(checksum, buffer, 0, size);
+            }
+            return checksum;
+        }
 
-		/// <summary>
-		/// Computes the checksum of a file
-		/// </summary>
-		/// <param name="path">The file to compute the checksum of</param>
-		/// <returns>The checksum for the file</returns>
-		public static int ComputeChecksum (string path)
-		{
-			using (FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read))
-			{
-				return ComputeChecksum(stream);
-			}
-		}
-	}
+        /// <summary>
+        /// Computes the checksum of a file
+        /// </summary>
+        /// <param name="path">The file to compute the checksum of</param>
+        /// <returns>The checksum for the file</returns>
+        public static int ComputeChecksum (string path)
+        {
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                return ComputeChecksum(stream);
+            }
+        }
+    }
 }

--- a/IO.Ably.DeltaCodec/Vcdiff/CodeTable.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/CodeTable.cs
@@ -2,136 +2,130 @@ using System;
 
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Table used to encode/decode instructions.
-	/// </summary>
-	internal sealed class CodeTable
-	{
-		/// <summary>
-		/// Default code table specified in RFC 3284.
-		/// </summary>
-		static internal CodeTable Default = BuildDefaultCodeTable();
+    /// <summary>
+    /// Table used to encode/decode instructions.
+    /// </summary>
+    internal sealed class CodeTable
+    {
+        /// <summary>
+        /// Default code table specified in RFC 3284.
+        /// </summary>
+        internal static readonly CodeTable Default = BuildDefaultCodeTable();
 
-		/// <summary>
-		/// Array of entries in the code table
-		/// </summary>
-		Instruction[,] entries = new Instruction[256,2];
+        /// <summary>
+        /// Array of entries in the code table
+        /// </summary>
+        private readonly Instruction[,] _entries = new Instruction[256,2];
 
-		/// <summary>
-		/// 
-		/// </summary>
-		internal Instruction this[int i, int j]
-		{
-			get
-			{
-				return entries[i, j];
-			}
-		}
+        /// <summary>
+        ///
+        /// </summary>
+        internal Instruction this[int i, int j] => _entries[i, j];
 
-		internal CodeTable(byte[] bytes)
-		{
-			for (int i=0; i < 256; i++)
-			{
-				entries[i,0] = new Instruction((InstructionType)bytes[i], bytes[i+512], bytes[i+1024]);
-				entries[i,1] = new Instruction((InstructionType)bytes[i+256], bytes[i+768], bytes[i+1280]);
-			}
-		}
+        internal CodeTable(byte[] bytes)
+        {
+            for (int i=0; i < 256; i++)
+            {
+                _entries[i,0] = new Instruction((InstructionType)bytes[i], bytes[i+512], bytes[i+1024]);
+                _entries[i,1] = new Instruction((InstructionType)bytes[i+256], bytes[i+768], bytes[i+1280]);
+            }
+        }
 
-		internal CodeTable(Instruction[,] entries)
-		{
-			if (entries==null)
-			{
-				throw new ArgumentNullException("entries");
-			}
-			if (entries.Rank != 2)
-			{
-				throw new ArgumentException ("Array must be rectangular.", "entries");
-			}
-			if (entries.GetLength(0) != 256)
-			{
-				throw new ArgumentException ("Array must have outer length 256.", "entries");
-			}
-			if (entries.GetLength(1) != 2)
-			{
-				throw new ArgumentException ("Array must have inner length 256.", "entries");
-			}
-			Array.Copy (entries, 0, this.entries, 0, 512);
-		}
+        internal CodeTable(Instruction[,] entries)
+        {
+            if (entries==null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+            if (entries.Rank != 2)
+            {
+                throw new ArgumentException ("Array must be rectangular.", nameof(entries));
+            }
+            if (entries.GetLength(0) != 256)
+            {
+                throw new ArgumentException ("Array must have outer length 256.", nameof(entries));
+            }
+            if (entries.GetLength(1) != 2)
+            {
+                throw new ArgumentException ("Array must have inner length 256.", nameof(entries));
+            }
+            Array.Copy (entries, 0, _entries, 0, 512);
+        }
 
-		/// <summary>
-		/// Builds the default code table specified in RFC 3284
-		/// </summary>
-		/// <returns>
-		/// The default code table.
-		/// </returns>
-		static CodeTable BuildDefaultCodeTable()
-		{
-			// Defaults are NoOps with size and mode 0.
-			Instruction[,] entries = new Instruction[256,2];
-			entries[0, 0] = new Instruction(InstructionType.Run, 0, 0);
-			for (byte i=0; i < 18; i++)
-			{
-				entries[i+1, 0] = new Instruction(InstructionType.Add, i, 0);
-			}
+        /// <summary>
+        /// Builds the default code table specified in RFC 3284
+        /// </summary>
+        /// <returns>
+        /// The default code table.
+        /// </returns>
+        private static CodeTable BuildDefaultCodeTable()
+        {
+            // Defaults are NoOps with size and mode 0.
+            var entries = new Instruction[256,2];
+            entries[0, 0] = new Instruction(InstructionType.Run, 0, 0);
+            for (byte i=0; i < 18; i++)
+            {
+                entries[i+1, 0] = new Instruction(InstructionType.Add, i, 0);
+            }
 
-			int index = 19;
+            int index = 19;
 
-			// Entries 19-162
-			for (byte mode = 0; mode < 9; mode++)
-			{
-				entries[index++, 0] = new Instruction (InstructionType.Copy, 0, mode);
-				for (byte size = 4; size < 19; size++)
-				{
-					entries[index++, 0] = new Instruction (InstructionType.Copy, size, mode);
-				}
-			}
+            // Entries 19-162
+            for (byte mode = 0; mode < 9; mode++)
+            {
+                entries[index++, 0] = new Instruction (InstructionType.Copy, 0, mode);
+                for (byte size = 4; size < 19; size++)
+                {
+                    entries[index++, 0] = new Instruction (InstructionType.Copy, size, mode);
+                }
+            }
 
-			// Entries 163-234
-			for (byte mode = 0; mode < 6; mode++)
-			{
-				for (byte addSize = 1; addSize < 5; addSize++)
-				{
-					for (byte copySize = 4; copySize < 7; copySize++)
-					{
-						entries[index, 0] = new Instruction (InstructionType.Add, addSize, 0);
-						entries[index++, 1] = new Instruction (InstructionType.Copy, copySize, mode);
-					}
-				}
-			}
+            // Entries 163-234
+            for (byte mode = 0; mode < 6; mode++)
+            {
+                for (byte addSize = 1; addSize < 5; addSize++)
+                {
+                    for (byte copySize = 4; copySize < 7; copySize++)
+                    {
+                        entries[index, 0] = new Instruction (InstructionType.Add, addSize, 0);
+                        entries[index++, 1] = new Instruction (InstructionType.Copy, copySize, mode);
+                    }
+                }
+            }
 
-			// Entries 235-246
-			for (byte mode = 6; mode < 9; mode++)
-			{
-				for (byte addSize = 1; addSize < 5; addSize++)
-				{
-					entries[index, 0] = new Instruction (InstructionType.Add, addSize, 0);
-					entries[index++, 1] = new Instruction (InstructionType.Copy, 4, mode);
-				}
-			}
+            // Entries 235-246
+            for (byte mode = 6; mode < 9; mode++)
+            {
+                for (byte addSize = 1; addSize < 5; addSize++)
+                {
+                    entries[index, 0] = new Instruction (InstructionType.Add, addSize, 0);
+                    entries[index++, 1] = new Instruction (InstructionType.Copy, 4, mode);
+                }
+            }
 
-			// Entries 247-255
-			for (byte mode = 0; mode < 9; mode++)
-			{
-				entries[index, 0] = new Instruction (InstructionType.Copy, 4, mode);
-				entries[index++, 1] = new Instruction (InstructionType.Add, 1, 0);
-			}
+            // Entries 247-255
+            for (byte mode = 0; mode < 9; mode++)
+            {
+                entries[index, 0] = new Instruction (InstructionType.Copy, 4, mode);
+                entries[index++, 1] = new Instruction (InstructionType.Add, 1, 0);
+            }
 
-			return new CodeTable(entries);
-		}
+            return new CodeTable(entries);
+        }
 
-		internal byte[] GetBytes()
-		{
-			byte[] ret = new byte[1536];
-			for (int i=0; i < 256; i++)
-			{
-				ret[i]=(byte)entries[i,0].Type;
-				ret[i+256]=(byte)entries[i,1].Type;
-				ret[i+512]=entries[i,0].Size;
-				ret[i+768]=entries[i,1].Size;
-				ret[i+1024]=entries[i,0].Mode;
-				ret[i+1280]=entries[i,1].Mode;
-			}
-			return ret;
-		}
-	}
+        internal byte[] GetBytes()
+        {
+            var ret = new byte[1536];
+            for (int i = 0; i < 256; i++)
+            {
+                ret[i]=(byte)_entries[i,0].Type;
+                ret[i+256] = (byte)_entries[i,1].Type;
+                ret[i+512] = _entries[i,0].Size;
+                ret[i+768] = _entries[i,1].Size;
+                ret[i+1024] = _entries[i,0].Mode;
+                ret[i+1280] = _entries[i,1].Mode;
+            }
+            return ret;
+        }
+    }
 }

--- a/IO.Ably.DeltaCodec/Vcdiff/IOHelper.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/IOHelper.cs
@@ -1,62 +1,60 @@
-using System;
 using System.IO;
 
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// A few IO routines to make life easier. Most are basically available
-	/// in EndianBinaryReader, but having them separately here makes VcdiffDecoder
-	/// more easily movable to other places - and no endianness issues are involved in
-	/// the first place.
-	/// </summary>
-	internal static class IOHelper
-	{
-		internal static byte[] CheckedReadBytes(Stream stream, int size)
-		{
-			byte[] ret = new byte[size];
-			int index=0;
-			while (index < size)
-			{
-				int read = stream.Read(ret, index, size-index);
-				if (read==0)
-				{
-					throw new EndOfStreamException
-						(String.Format("End of stream reached with {0} byte{1} left to read.", size-index,
-						size-index==1 ? "s" : ""));
-				}
-				index += read;
-			}
-			return ret;
-		}
+    /// <summary>
+    /// A few IO routines to make life easier. Most are basically available
+    /// in EndianBinaryReader, but having them separately here makes VcdiffDecoder
+    /// more easily movable to other places - and no endianness issues are involved in
+    /// the first place.
+    /// </summary>
+    internal static class IoHelper
+    {
+        internal static byte[] CheckedReadBytes(Stream stream, int size)
+        {
+            byte[] ret = new byte[size];
+            int index=0;
+            while (index < size)
+            {
+                int read = stream.Read(ret, index, size-index);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException
+                        ($"End of stream reached with {size - index} byte{(size - index == 1 ? "s" : "")} left to read.");
+                }
+                index += read;
+            }
+            return ret;
+        }
 
-		internal static byte CheckedReadByte (Stream stream)
-		{
-			int b = stream.ReadByte();
-			if (b==-1)
-			{
-				throw new IOException ("Expected to be able to read a byte.");
-			}
-			return (byte)b;
-		}
+        internal static byte CheckedReadByte (Stream stream)
+        {
+            int b = stream.ReadByte();
+            if (b == -1)
+            {
+                throw new IOException ("Expected to be able to read a byte.");
+            }
+            return (byte)b;
+        }
 
-		internal static int ReadBigEndian7BitEncodedInt(Stream stream)
-		{
-			int ret=0;
-			for (int i=0; i < 5; i++)
-			{
-				int b = stream.ReadByte();
-				if (b==-1)
-				{
-					throw new EndOfStreamException();
-				}
-				ret = (ret << 7) | (b&0x7f);
-				if ((b & 0x80) == 0)
-				{
-					return ret;
-				}
-			}
-			// Still haven't seen a byte with the high bit unset? Dodgy data.
-			throw new IOException("Invalid 7-bit encoded integer in stream.");
-		}
-	}
+        internal static int ReadBigEndian7BitEncodedInt(Stream stream)
+        {
+            int ret = 0;
+            for (int i = 0; i < 5; i++)
+            {
+                int b = stream.ReadByte();
+                if (b == -1)
+                {
+                    throw new EndOfStreamException();
+                }
+                ret = (ret << 7) | (b&0x7f);
+                if ((b & 0x80) == 0)
+                {
+                    return ret;
+                }
+            }
+            // Still haven't seen a byte with the high bit unset? Dodgy data.
+            throw new IOException("Invalid 7-bit encoded integer in stream.");
+        }
+    }
 }

--- a/IO.Ably.DeltaCodec/Vcdiff/Instruction.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/Instruction.cs
@@ -1,37 +1,22 @@
-
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Contains the information for a single instruction
-	/// </summary>
-	internal struct Instruction
-	{
-		readonly InstructionType type;
-		internal InstructionType Type
-		{
-			get { return type; }
-		}
+    /// <summary>
+    /// Contains the information for a single instruction
+    /// </summary>
+    internal readonly struct Instruction
+    {
+        internal InstructionType Type { get; }
 
-		readonly byte size;
-		internal byte Size
-		{
-			get { return size; }
-		}
+        internal byte Size { get; }
 
-		readonly byte mode;
-		internal byte Mode
-		{
-			get { return mode; }
-		}
+        internal byte Mode { get; }
 
-		internal Instruction(InstructionType type, byte size, byte mode)
-		{
-			this.type = type;
-			this.size = size;
-			this.mode = mode;
-		}
-
-
-	}
+        internal Instruction(InstructionType type, byte size, byte mode)
+        {
+            Type = type;
+            Size = size;
+            Mode = mode;
+        }
+    }
 }
 

--- a/IO.Ably.DeltaCodec/Vcdiff/InstructionType.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/InstructionType.cs
@@ -1,14 +1,13 @@
-
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Enumeration of the different instruction types.
-	/// </summary>
-	internal enum InstructionType : byte
-	{
-		NoOp=0,
-		Add=1,
-		Run=2,
-		Copy=3
-	}
+    /// <summary>
+    /// Enumeration of the different instruction types.
+    /// </summary>
+    internal enum InstructionType : byte
+    {
+        NoOp = 0,
+        Add = 1,
+        Run = 2,
+        Copy = 3
+    }
 }

--- a/IO.Ably.DeltaCodec/Vcdiff/VcdiffDecoder.cs
+++ b/IO.Ably.DeltaCodec/Vcdiff/VcdiffDecoder.cs
@@ -3,375 +3,378 @@ using System.IO;
 
 namespace IO.Ably.DeltaCodec.Vcdiff
 {
-	/// <summary>
-	/// Decoder for VCDIFF (RFC 3284) streams.
-	/// </summary>
-	internal sealed class VcdiffDecoder
-	{
-		#region Fields
-		/// <summary>
-		/// Reader containing original data, if any. May be null.
-		/// If non-null, will be readable and seekable.
-		/// </summary>
-		Stream original;
+    /// <summary>
+    /// Decoder for VCDIFF (RFC 3284) streams.
+    /// </summary>
+    internal sealed class VcdiffDecoder
+    {
+        #region Fields
+        /// <summary>
+        /// Reader containing original data, if any. May be null.
+        /// If non-null, will be readable and seekable.
+        /// </summary>
+        private readonly Stream _original;
 
-		/// <summary>
-		/// Stream containing delta data. Will be readable.
-		/// </summary>
-		Stream delta;
-		
-		/// <summary>
-		/// Stream containing target data. Will be readable,
-		/// writable and seekable.
-		/// </summary>
-		Stream output;
+        /// <summary>
+        /// Stream containing delta data. Will be readable.
+        /// </summary>
+        private readonly Stream _delta;
 
-		/// <summary>
-		/// Code table to use for decoding.
-		/// </summary>
-		CodeTable codeTable = CodeTable.Default;
+        /// <summary>
+        /// Stream containing target data. Will be readable,
+        /// writable and seekable.
+        /// </summary>
+        private readonly Stream _output;
 
-		/// <summary>
-		/// Address cache to use when decoding; must be reset before decoding each window.
-		/// Default to the default size.
-		/// </summary>
-		AddressCache cache = new AddressCache(4, 3);
-		#endregion
+        /// <summary>
+        /// Code table to use for decoding.
+        /// </summary>
+        private CodeTable _codeTable = CodeTable.Default;
 
-		#region Constructor
-		/// <summary>
-		/// Sole constructor; private to prevent instantiation from
-		/// outside the class.
-		/// </summary>
-		VcdiffDecoder(Stream original, Stream delta, Stream output)
-		{
-			this.original = original;
-			this.delta = delta;
-			this.output = output;
-		}
-		#endregion
+        /// <summary>
+        /// Address cache to use when decoding; must be reset before decoding each window.
+        /// Default to the default size.
+        /// </summary>
+        private AddressCache _cache = new AddressCache(4, 3);
+        #endregion
 
-		#region Public interface
-		/// <summary>
-		/// Decodes an original stream and a delta stream, writing to a target stream.
-		/// The original stream may be null, so long as the delta stream never
-		/// refers to it. The original and delta streams must be readable, and the
-		/// original stream (if any) and the target stream must be seekable. 
-		/// The target stream must be writable and readable. The original and target
-		/// streams are rewound to their starts before any data is read; the relevant data
-		/// must occur at the beginning of the original stream, and any data already present
-		/// in the target stream may be overwritten. The delta data must begin
-		/// wherever the delta stream is currently positioned. The delta stream must end
-		/// after the last window. The streams are not disposed by this method.
-		/// </summary>
-		/// <param name="original">Stream containing delta. May be null.</param>
-		/// <param name="delta">Stream containing delta data.</param>
-		/// <param name="output">Stream to write resulting data to.</param>
-		public static void Decode (Stream original, Stream delta, Stream output)
-		{
-			#region Simple argument checking
-			if (original != null && (!original.CanRead || !original.CanSeek))
-			{
-				throw new ArgumentException ("Must be able to read and seek in original stream", "original");
-			}
-			if (delta==null)
-			{
-				throw new ArgumentNullException("delta");
-			}
-			if (!delta.CanRead)
-			{
-				throw new ArgumentException ("Unable to read from delta stream");
-			}
-			if (output==null)
-			{
-				throw new ArgumentNullException("output");
-			}
-			if (!output.CanWrite || !output.CanRead || !output.CanSeek)
-			{
-				throw new ArgumentException ("Must be able to read, write and seek in output stream", "output");
-			}
-			#endregion
+        #region Constructor
+        /// <summary>
+        /// Sole constructor; private to prevent instantiation from
+        /// outside the class.
+        /// </summary>
+        private VcdiffDecoder(Stream original, Stream delta, Stream output)
+        {
+            _original = original;
+            _delta = delta;
+            _output = output;
+        }
+        #endregion
 
-			// Now the arguments are checked, we construct an instance of the
-			// class and ask it to do the decoding.
-			VcdiffDecoder instance = new VcdiffDecoder(original, delta, output);
-			instance.Decode();
-		}
-		#endregion
+        #region Public interface
+        /// <summary>
+        /// Decodes an original stream and a delta stream, writing to a target stream.
+        /// The original stream may be null, so long as the delta stream never
+        /// refers to it. The original and delta streams must be readable, and the
+        /// original stream (if any) and the target stream must be seekable.
+        /// The target stream must be writable and readable. The original and target
+        /// streams are rewound to their starts before any data is read; the relevant data
+        /// must occur at the beginning of the original stream, and any data already present
+        /// in the target stream may be overwritten. The delta data must begin
+        /// wherever the delta stream is currently positioned. The delta stream must end
+        /// after the last window. The streams are not disposed by this method.
+        /// </summary>
+        /// <param name="original">Stream containing delta. May be null.</param>
+        /// <param name="delta">Stream containing delta data.</param>
+        /// <param name="output">Stream to write resulting data to.</param>
+        public static void Decode (Stream original, Stream delta, Stream output)
+        {
+            #region Simple argument checking
+            if (original != null && (!original.CanRead || !original.CanSeek))
+            {
+                throw new ArgumentException ("Must be able to read and seek in original stream", nameof(original));
+            }
+            if (delta==null)
+            {
+                throw new ArgumentNullException(nameof(delta));
+            }
+            if (!delta.CanRead)
+            {
+                throw new ArgumentException ("Unable to read from delta stream");
+            }
+            if (output==null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+            if (!output.CanWrite || !output.CanRead || !output.CanSeek)
+            {
+                throw new ArgumentException ("Must be able to read, write and seek in output stream", nameof(output));
+            }
+            #endregion
 
-		#region Private methods
-		/// <summary>
-		/// Top-level decoding method. When this method exits, all decoding has been performed.
-		/// </summary>
-		void Decode()
-		{
-			ReadHeader();
-			
-			while (DecodeWindow());
-		}
+            // Now the arguments are checked, we construct an instance of the
+            // class and ask it to do the decoding.
+            VcdiffDecoder instance = new VcdiffDecoder(original, delta, output);
+            instance.Decode();
+        }
+        #endregion
 
-		/// <summary>
-		/// Read the header, including any custom code table. The delta stream is left
-		/// positioned at the start of the first window.
-		/// </summary>
-		void ReadHeader()
-		{
-			byte[] header = IOHelper.CheckedReadBytes(delta, 4);
-			if (header[0] != 0xd6 ||
-				header[1] != 0xc3 ||
-				header[2] != 0xc4)
-			{
-				throw new VcdiffFormatException("Invalid VCDIFF header in delta stream");
-			}
-			if (header[3] != 0)
-			{
-				throw new VcdiffFormatException("VcdiffDecoder can only read delta streams of version 0");
-			}
+        #region Private methods
+        /// <summary>
+        /// Top-level decoding method. When this method exits, all decoding has been performed.
+        /// </summary>
+        private void Decode()
+        {
+            ReadHeader();
 
-			// Load the header indicator
-			byte headerIndicator = IOHelper.CheckedReadByte(delta);
-			if ((headerIndicator&1) != 0)
-			{
-				throw new VcdiffFormatException
-					("VcdiffDecoder does not handle delta stream using secondary compressors");
-			}
-			bool customCodeTable = ((headerIndicator&2) != 0);
-			bool applicationHeader = ((headerIndicator&4) != 0);
+            while (DecodeWindow())
+            {
+                // Intentionally empty statement body.
+            }
+        }
 
-			if ((headerIndicator & 0xf8) != 0)
-			{
-				throw new VcdiffFormatException ("Invalid header indicator - bits 3-7 not all zero.");
-			}
+        /// <summary>
+        /// Read the header, including any custom code table. The delta stream is left
+        /// positioned at the start of the first window.
+        /// </summary>
+        private void ReadHeader()
+        {
+            byte[] header = IoHelper.CheckedReadBytes(_delta, 4);
+            if (header[0] != 0xd6 ||
+                header[1] != 0xc3 ||
+                header[2] != 0xc4)
+            {
+                throw new VcdiffFormatException("Invalid VCDIFF header in delta stream");
+            }
+            if (header[3] != 0)
+            {
+                throw new VcdiffFormatException("VcdiffDecoder can only read delta streams of version 0");
+            }
 
-			// Load the custom code table, if there is one
-			if (customCodeTable)
-			{
-				ReadCodeTable();
-			}
+            // Load the header indicator
+            byte headerIndicator = IoHelper.CheckedReadByte(_delta);
+            if ((headerIndicator&1) != 0)
+            {
+                throw new VcdiffFormatException
+                    ("VcdiffDecoder does not handle delta stream using secondary compressors");
+            }
+            bool customCodeTable = ((headerIndicator&2) != 0);
+            bool applicationHeader = ((headerIndicator&4) != 0);
 
-			// Ignore the application header if we have one. This tells xdelta3 what the right filenames are.
-			if (applicationHeader)
-			{
-				int appHeaderLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-				IOHelper.CheckedReadBytes(delta, appHeaderLength);
-			}
-		}
+            if ((headerIndicator & 0xf8) != 0)
+            {
+                throw new VcdiffFormatException ("Invalid header indicator - bits 3-7 not all zero.");
+            }
 
-		/// <summary>
-		/// Reads the custom code table, if there is one
-		/// </summary>
-		void ReadCodeTable()
-		{
-			// The length given includes the nearSize and sameSize bytes
-			int compressedTableLength = IOHelper.ReadBigEndian7BitEncodedInt(delta)-2;
-			int nearSize = IOHelper.CheckedReadByte(delta);
-			int sameSize = IOHelper.CheckedReadByte(delta);
-			byte[] compressedTableData = IOHelper.CheckedReadBytes(delta, compressedTableLength);
+            // Load the custom code table, if there is one
+            if (customCodeTable)
+            {
+                ReadCodeTable();
+            }
 
-			byte[] defaultTableData = CodeTable.Default.GetBytes();
+            // Ignore the application header if we have one. This tells xdelta3 what the right filenames are.
+            if (applicationHeader)
+            {
+                int appHeaderLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
+                IoHelper.CheckedReadBytes(_delta, appHeaderLength);
+            }
+        }
 
-			MemoryStream tableOriginal = new MemoryStream(defaultTableData, false);
-			MemoryStream tableDelta = new MemoryStream(compressedTableData, false);
-			byte[] decompressedTableData = new byte[1536];
-			MemoryStream tableOutput = new MemoryStream(decompressedTableData, true);
-			VcdiffDecoder.Decode(tableOriginal, tableDelta, tableOutput);
+        /// <summary>
+        /// Reads the custom code table, if there is one
+        /// </summary>
+        private void ReadCodeTable()
+        {
+            // The length given includes the nearSize and sameSize bytes
+            int compressedTableLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta)-2;
+            int nearSize = IoHelper.CheckedReadByte(_delta);
+            int sameSize = IoHelper.CheckedReadByte(_delta);
+            byte[] compressedTableData = IoHelper.CheckedReadBytes(_delta, compressedTableLength);
 
-			if (tableOutput.Position != 1536)
-			{
-				throw new VcdiffFormatException("Compressed code table was incorrect size");
-			}
+            byte[] defaultTableData = CodeTable.Default.GetBytes();
 
-			codeTable = new CodeTable(decompressedTableData);
-			cache = new AddressCache(nearSize, sameSize);
-		}
+            var tableOriginal = new MemoryStream(defaultTableData, false);
+            var tableDelta = new MemoryStream(compressedTableData, false);
+            var decompressedTableData = new byte[1536];
+            var tableOutput = new MemoryStream(decompressedTableData, true);
+            Decode(tableOriginal, tableDelta, tableOutput);
 
-		/// <summary>
-		/// Reads and decodes a window, returning whether or not there was
-		/// any more data to read.
-		/// </summary>
-		/// <returns>
-		/// Whether or not the delta stream had reached the end of its data.
-		/// </returns>
-		bool DecodeWindow ()
-		{
-			int windowIndicator = delta.ReadByte();
-			// Have we finished?
-			if (windowIndicator==-1)
-			{
-				return false;
-			}
-			
-			// The stream to load source data from for this window, if any
-			Stream sourceStream;
-			// Where to reposition the source stream to after reading from it, if anywhere
-			int sourceStreamPostReadSeek=-1;
+            if (tableOutput.Position != 1536)
+            {
+                throw new VcdiffFormatException("Compressed code table was incorrect size");
+            }
 
-			// xdelta3 uses an undocumented extra bit which indicates that there are an extra
-			// 4 bytes at the end of the encoding for the window
-			bool hasAdler32Checksum = ((windowIndicator&4)==4);
+            _codeTable = new CodeTable(decompressedTableData);
+            _cache = new AddressCache(nearSize, sameSize);
+        }
 
-			// Get rid of the checksum bit for the rest
-			windowIndicator &= 0xfb;
+        /// <summary>
+        /// Reads and decodes a window, returning whether or not there was
+        /// any more data to read.
+        /// </summary>
+        /// <returns>
+        /// Whether or not the delta stream had reached the end of its data.
+        /// </returns>
+        private bool DecodeWindow ()
+        {
+            int windowIndicator = _delta.ReadByte();
+            // Have we finished?
+            if (windowIndicator==-1)
+            {
+                return false;
+            }
 
-			// Work out what the source data is, and detect invalid window indicators
-			switch (windowIndicator&3)
-			{
-				// No source data used in this window
-				case 0:
-					sourceStream = null;
-					break;
-				// Source data comes from the original stream
-				case 1:
-					if (original==null)
-					{
-						throw new VcdiffFormatException
-							("Source stream requested by delta but not provided by caller.");
-					}
-					sourceStream = original;
-					break;
-				case 2:
-					sourceStream = output;
-					sourceStreamPostReadSeek = (int)output.Position;
-					break;
-				case 3:								
-					throw new VcdiffFormatException
-						("Invalid window indicator - bits 0 and 1 both set.");			
-				default:
-					throw new VcdiffFormatException("Invalid window indicator - bits 3-7 not all zero.");
-			}
+            // The stream to load source data from for this window, if any
+            Stream sourceStream;
+            // Where to reposition the source stream to after reading from it, if anywhere
+            int sourceStreamPostReadSeek=-1;
 
-			// Read the source data, if any
-			byte[] sourceData = null;
-			int sourceLength = 0;
-			if (sourceStream != null)
-			{
-				sourceLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-				int sourcePosition = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-		
-				sourceStream.Position = sourcePosition;
+            // xdelta3 uses an undocumented extra bit which indicates that there are an extra
+            // 4 bytes at the end of the encoding for the window
+            bool hasAdler32Checksum = ((windowIndicator&4)==4);
 
-				sourceData = IOHelper.CheckedReadBytes(sourceStream, sourceLength);
-				// Reposition the source stream if appropriate
-				if (sourceStreamPostReadSeek != -1)
-				{
-					sourceStream.Position = sourceStreamPostReadSeek;
-				}
-			}
+            // Get rid of the checksum bit for the rest
+            windowIndicator &= 0xfb;
 
-			// Read how long the delta encoding is - then ignore it
-			IOHelper.ReadBigEndian7BitEncodedInt(delta);
+            // Work out what the source data is, and detect invalid window indicators
+            switch (windowIndicator&3)
+            {
+                // No source data used in this window
+                case 0:
+                    sourceStream = null;
+                    break;
+                // Source data comes from the original stream
+                case 1:
+                    if (_original == null)
+                    {
+                        throw new VcdiffFormatException
+                            ("Source stream requested by delta but not provided by caller.");
+                    }
+                    sourceStream = _original;
+                    break;
+                case 2:
+                    sourceStream = _output;
+                    sourceStreamPostReadSeek = (int)_output.Position;
+                    break;
+                case 3:
+                    throw new VcdiffFormatException
+                        ("Invalid window indicator - bits 0 and 1 both set.");
+                default:
+                    throw new VcdiffFormatException("Invalid window indicator - bits 3-7 not all zero.");
+            }
 
-			// Read how long the target window is
-			int targetLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-			byte[] targetData = new byte[targetLength];
-			MemoryStream targetDataStream = new MemoryStream(targetData, true);
+            // Read the source data, if any
+            byte[] sourceData = null;
+            int sourceLength = 0;
+            if (sourceStream != null)
+            {
+                sourceLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
+                int sourcePosition = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
 
-			// Read the indicator and the lengths of the different data sections
-			byte deltaIndicator = IOHelper.CheckedReadByte(delta);
-			if (deltaIndicator != 0)
-			{
-				throw new VcdiffFormatException("VcdiffDecoder is unable to handle compressed delta sections.");
-			}
+                sourceStream.Position = sourcePosition;
 
-			int addRunDataLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-			int instructionsLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
-			int addressesLength = IOHelper.ReadBigEndian7BitEncodedInt(delta);
+                sourceData = IoHelper.CheckedReadBytes(sourceStream, sourceLength);
+                // Reposition the source stream if appropriate
+                if (sourceStreamPostReadSeek != -1)
+                {
+                    sourceStream.Position = sourceStreamPostReadSeek;
+                }
+            }
 
-			// If we've been given a checksum, we have to read it and we might as well
-			// use it to check the data.
-			int checksumInFile=0;
-			if (hasAdler32Checksum)
-			{
-				byte[] checksumBytes = IOHelper.CheckedReadBytes(delta, 4);
-				checksumInFile = (checksumBytes[0]<<24) |
-					             (checksumBytes[1]<<16) |
-					             (checksumBytes[2]<<8) |
-					             checksumBytes[3];
-			}
+            // Read how long the delta encoding is - then ignore it
+            IoHelper.ReadBigEndian7BitEncodedInt(_delta);
 
-			// Read all the data for this window
-			byte[] addRunData = IOHelper.CheckedReadBytes(delta, addRunDataLength);
-			byte[] instructions = IOHelper.CheckedReadBytes(delta, instructionsLength);
-			byte[] addresses = IOHelper.CheckedReadBytes(delta, addressesLength);
+            // Read how long the target window is
+            int targetLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
+            var targetData = new byte[targetLength];
+            var targetDataStream = new MemoryStream(targetData, true);
 
-			int addRunDataIndex = 0;
+            // Read the indicator and the lengths of the different data sections
+            byte deltaIndicator = IoHelper.CheckedReadByte(_delta);
+            if (deltaIndicator != 0)
+            {
+                throw new VcdiffFormatException("VcdiffDecoder is unable to handle compressed delta sections.");
+            }
 
-			MemoryStream instructionStream = new MemoryStream(instructions, false);
+            int addRunDataLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
+            int instructionsLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
+            int addressesLength = IoHelper.ReadBigEndian7BitEncodedInt(_delta);
 
-			cache.Reset(addresses);
+            // If we've been given a checksum, we have to read it and we might as well
+            // use it to check the data.
+            int checksumInFile=0;
+            if (hasAdler32Checksum)
+            {
+                byte[] checksumBytes = IoHelper.CheckedReadBytes(_delta, 4);
+                checksumInFile = (checksumBytes[0]<<24) |
+                                 (checksumBytes[1]<<16) |
+                                 (checksumBytes[2]<<8) |
+                                 checksumBytes[3];
+            }
 
-			while (true)
-			{
-				int instructionIndex = instructionStream.ReadByte();
-				if (instructionIndex==-1)
-				{
-					break;
-				}
-				
-				for (int i=0; i < 2; i++)
-				{
-					Instruction instruction = codeTable[instructionIndex, i];
-					int size = instruction.Size;
-					if (size==0 && instruction.Type != InstructionType.NoOp)
-					{
-						size = IOHelper.ReadBigEndian7BitEncodedInt(instructionStream);
-					}
-					switch (instruction.Type)
-					{
-						case InstructionType.NoOp:
-							break;
-						case InstructionType.Add:
-							targetDataStream.Write(addRunData, addRunDataIndex, size);
-							addRunDataIndex += size;
-							break;
-						case InstructionType.Copy:
-							int addr = cache.DecodeAddress((int)targetDataStream.Position+sourceLength, instruction.Mode);							
-							if (sourceData != null && addr < sourceData.Length)
-							{
-								targetDataStream.Write(sourceData, addr, size);
-							}
-							else // Data is in target data
-							{
-								// Get rid of the offset
-								addr -= sourceLength;
-								// Can we just ignore overlap issues?
-								if (addr + size < targetDataStream.Position)
-								{
-									targetDataStream.Write(targetData, addr, size);
-								}
-								else
-								{
-									for (int j=0; j < size; j++)
-									{
-										targetDataStream.WriteByte(targetData[addr++]);
-									}
-								}
-							}
-							break;
-						case InstructionType.Run:
-							byte data = addRunData[addRunDataIndex++];
-							for (int j=0; j < size; j++)
-							{
-								targetDataStream.WriteByte(data);
-							}
-							break;
-						default:
-							throw new VcdiffFormatException("Invalid instruction type found.");
-					}
-				}
-			}
-			output.Write(targetData, 0, targetLength);
-			
-			if (hasAdler32Checksum)
-			{
-				int actualChecksum = Adler32.ComputeChecksum(1, targetData);
-				if (actualChecksum != checksumInFile)
-				{
-					throw new VcdiffFormatException("Invalid checksum after decoding window");
-				}
-			}
-			return true;
-		}
-		#endregion
-	}
+            // Read all the data for this window
+            byte[] addRunData = IoHelper.CheckedReadBytes(_delta, addRunDataLength);
+            byte[] instructions = IoHelper.CheckedReadBytes(_delta, instructionsLength);
+            byte[] addresses = IoHelper.CheckedReadBytes(_delta, addressesLength);
+
+            int addRunDataIndex = 0;
+
+            var instructionStream = new MemoryStream(instructions, false);
+
+            _cache.Reset(addresses);
+
+            while (true)
+            {
+                int instructionIndex = instructionStream.ReadByte();
+                if (instructionIndex == -1)
+                {
+                    break;
+                }
+
+                for (int i = 0; i < 2; i++)
+                {
+                    Instruction instruction = _codeTable[instructionIndex, i];
+                    int size = instruction.Size;
+                    if (size == 0 && instruction.Type != InstructionType.NoOp)
+                    {
+                        size = IoHelper.ReadBigEndian7BitEncodedInt(instructionStream);
+                    }
+                    switch (instruction.Type)
+                    {
+                        case InstructionType.NoOp:
+                            break;
+                        case InstructionType.Add:
+                            targetDataStream.Write(addRunData, addRunDataIndex, size);
+                            addRunDataIndex += size;
+                            break;
+                        case InstructionType.Copy:
+                            int addr = _cache.DecodeAddress((int)targetDataStream.Position+sourceLength, instruction.Mode);
+                            if (sourceData != null && addr < sourceData.Length)
+                            {
+                                targetDataStream.Write(sourceData, addr, size);
+                            }
+                            else // Data is in target data
+                            {
+                                // Get rid of the offset
+                                addr -= sourceLength;
+                                // Can we just ignore overlap issues?
+                                if (addr + size < targetDataStream.Position)
+                                {
+                                    targetDataStream.Write(targetData, addr, size);
+                                }
+                                else
+                                {
+                                    for (int j = 0; j < size; j++)
+                                    {
+                                        targetDataStream.WriteByte(targetData[addr++]);
+                                    }
+                                }
+                            }
+                            break;
+                        case InstructionType.Run:
+                            byte data = addRunData[addRunDataIndex++];
+                            for (int j = 0; j < size; j++)
+                            {
+                                targetDataStream.WriteByte(data);
+                            }
+                            break;
+                        default:
+                            throw new VcdiffFormatException("Invalid instruction type found.");
+                    }
+                }
+            }
+            _output.Write(targetData, 0, targetLength);
+
+            if (hasAdler32Checksum)
+            {
+                int actualChecksum = Adler32.ComputeChecksum(1, targetData);
+                if (actualChecksum != checksumInFile)
+                {
+                    throw new VcdiffFormatException("Invalid checksum after decoding window");
+                }
+            }
+            return true;
+        }
+        #endregion
+    }
 }


### PR DESCRIPTION
Fixes a bunch of warnings and brings the code base more inline (style wise) with `Ably.NET`.

I have applied things like `readonly` where possible and used `var` where the inferred type is obvious from the right-hand side of the expression.

I have also normalised the mixed tabs and spaces to the defacto standard of 4 spaces for a logical tab.

If you review this in an external diff tool and enable Ignore All Whitespace Changes you'll have a much easier time reviewing it.