### PR TITLE
Add '.editorconfig' to help preserve white space changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://EditorConfig.org
+# https://visualstudiogallery.msdn.microsoft.com/c8bccfe2-650c-4b42-bc5c-845e21f96328
+
+# top-most EditorConfig file
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none
+
+[*.{xaml,xml,config,manifest}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = false


### PR DESCRIPTION
Now that we've cleared up the white space inconsistencies adding a `.editorconfig` will help keep them tidy (assuming Visual Studio* is used).