### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: 6.0.x
 
@@ -37,7 +37,7 @@ jobs:
         run: dotnet test --configuration Release --no-build --verbosity normal --logger "junit;LogFileName=unit.junit"
 
       - name: View unit test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if: success() || failure()
         with:
           name: Unit Test Results

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,9 +6,14 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on `actions/checkout` so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
- Scope each job's permissions explicitly: top-level `permissions: {}`, with the `check` job granted only the `GITHUB_TOKEN` scopes it actually needs (`contents: read` for checkout, `checks: write` for `dorny/test-reporter`).
- Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflow runs the same checks against the same inputs.